### PR TITLE
join-failedイベントについてREADMEに記載

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ cli.sendSystemCommand('happyEmotionDetected', { value: true });
 ### events
  * **connect**: when connected to minarai successfully
  * **joined**: when signed in to minarai as client successfully
+ * **join-failed**: when signing in to minarai was failed
  * **disconnected**: when disconnected to minarai successfully
  * **sync**: when you or your group send message to minarai(for sync message between multiple devices)
  * **sync-system-command**: when you or your group send system command to minarai(for sync system command between multiple devices)


### PR DESCRIPTION
`join-failed`について記載が抜けていたため記載しました

実装は前からこのようにあった模様です 🙇 🙇 🙇 

https://github.com/Nextremer/minarai-client-sdk-js-socket.io/blob/master/src/ts/minarai-client.ts#L98-L101