### PR TITLE
インスタンス変数userAuthParamsを追加し、join時に送信するようにする

### DIFF
--- a/dist/minarai-client.js
+++ b/dist/minarai-client.js
@@ -113,6 +113,7 @@ var MinaraiClient = (function (_super) {
         this.lang = opts.lang || 'ja-JP';
         this.imageUrl = socketIORootURL.replace(/\/$/, '') + "/" + apiVersion + "/upload-image";
         this.getImageByHeader = opts.getImageByHeader;
+        this.userAuth = opts.userAuth;
         logger.set({ debug: opts.debug, silent: opts.silent });
     }
     MinaraiClient.prototype.init = function () {
@@ -126,6 +127,7 @@ var MinaraiClient = (function (_super) {
                 clientId: _this.clientId,
                 userId: _this.userId,
                 deviceId: _this.deviceId,
+                userAuth: _this.userAuth,
             });
         });
         this.socket.on('join-failed', function (e) {
@@ -235,6 +237,7 @@ var MinaraiClient = (function (_super) {
             user_id: id,
             password: pass,
             token: token,
+            userAuth: this.userAuth,
         });
     };
     MinaraiClient.prototype.sendSystemCommand = function (command, payload) {

--- a/src/ts/minarai-client.ts
+++ b/src/ts/minarai-client.ts
@@ -23,6 +23,7 @@ export interface MinaraiClientConstructorOptions {
   debug?: boolean;
   silent?: boolean;
   getImageByHeader: boolean;
+  userAuth?: object;
 }
 
 export interface SendOptions {
@@ -44,6 +45,7 @@ export default class MinaraiClient extends EventEmitter2.EventEmitter2 {
   private userId: string|number;
   private deviceId: string|number;
   private lang: string|number;
+  private userAuth: object;
 
   constructor(opts: MinaraiClientConstructorOptions) {
     super();
@@ -77,6 +79,7 @@ export default class MinaraiClient extends EventEmitter2.EventEmitter2 {
     this.lang = opts.lang || 'ja-JP';
     this.imageUrl = `${socketIORootURL.replace(/\/$/, '')}/${apiVersion}/upload-image`;
     this.getImageByHeader = opts.getImageByHeader;
+    this.userAuth = opts.userAuth;
 
     logger.set({debug: opts.debug, silent: opts.silent});
   }
@@ -92,6 +95,7 @@ export default class MinaraiClient extends EventEmitter2.EventEmitter2 {
         clientId: this.clientId,
         userId: this.userId,
         deviceId: this.deviceId,
+        userAuth: this.userAuth,
       });
     });
 
@@ -213,6 +217,7 @@ export default class MinaraiClient extends EventEmitter2.EventEmitter2 {
       user_id: id,
       password: pass,
       token: token,
+      userAuth: this.userAuth,
     });
   }
 

--- a/test/ts/minarai-client.spec.ts
+++ b/test/ts/minarai-client.spec.ts
@@ -66,18 +66,11 @@ describe('MinaraiClient', () => {
     });
 
     describe('without required params', () => {
-      it('expect to throw InvalidArgumentError', () => {
+      it('expect to throw InvalidArgumentError(when io is null or applicationId is null)', () => {
         expect(() => {
           new MinaraiClient({
             ...constructorOptions,
             io: null,
-          })
-        }).to.throw(MinaraiClient.InvalidArgumentError);
-        expect(() => {
-          new MinaraiClient({
-            ...constructorOptions,
-            socketIORootURL: null,
-            applicationSecret: null,
           })
         }).to.throw(MinaraiClient.InvalidArgumentError);
         expect(() => {


### PR DESCRIPTION
## 概要（[issue](https://github.com/Nextremer/minarai-project/issues/989)）

インスタンス変数にuser情報を保持し、`join-as-client`イベント送信時に送るpayloadにそのuser情報をを追加しました:dolphin:
また、失敗するテストが一つあったので修正しています。

d-hubも修正していますのでご確認お願いします🙇（アプリサーバまで情報が渡るようにするため）
https://github.com/Nextremer/minarai-daialogue-hub/pull/426

## 実装詳細

```js
// (minarai-cs-chat-front)
new MinaraiClient({
  userAuthParams: { token: 'hoge' },
})
```
↑のように`userAuthParams` を渡すことで、インスタンス変数として保持し、その変数値を`socket.emit('join-as-client', ...)`でsocketio-connectorへ送信するようにしました。

userAuthParamsというインスタンス変数名にしましたが、もっと良い名前があれば教えて頂きたいです:bow-sasaoka:

## テスト修正詳細

```js
expect(() => {
  new MinaraiClient({
    ...constructorOptions,
    socketIORootURL: null,
    applicationSecret: null,　// これがnullの場合
  })
}).to.throw(MinaraiClient.InvalidArgumentError); // errorを期待する
```

↑で失敗していたためこのexpectを消すことで対処しました。

`消した理由`
まずテストが失敗していた理由は、インスタンス作成時にapplicationSecretが渡されないと、エラーを発生させる!!というコードがコメントアウトされていたためです。-> [コード](https://github.com/Nextremer/minarai-client-sdk-js-socket.io/blob/master/src/ts/minarai-client.ts#L56)
コメントアウトを外しエラー発生を復活させると、既存のアプリに影響が出るようなのでテストコードを消すことを選択しました。
*コメントアウトしているこのコミットのメッセージ参照 -> https://github.com/Nextremer/minarai-client-sdk-js-socket.io/commit/872d7db8bd71ce310029b474792e41ca0f1d2413

## 期限

7/11 ~12:00まででお願いします！