### PR TITLE
ユーザ認証で得られたラベルを保持してminaraiに送信する

### DIFF
--- a/dist/minarai-client.js
+++ b/dist/minarai-client.js
@@ -114,6 +114,7 @@ var MinaraiClient = (function (_super) {
         this.imageUrl = socketIORootURL.replace(/\/$/, '') + "/" + apiVersion + "/upload-image";
         this.getImageByHeader = opts.getImageByHeader;
         this.userAuth = opts.userAuth;
+        this.userProfile = {};
         logger.set({ debug: opts.debug, silent: opts.silent });
     }
     MinaraiClient.prototype.init = function () {
@@ -144,6 +145,10 @@ var MinaraiClient = (function (_super) {
             _this.clientId = data.clientId;
             _this.userId = data.userId;
             _this.deviceId = data.deviceId;
+            if (data.extra && data.extra.userProfile !== null) {
+                _this.userProfile = Object.assign({}, _this.userProfile, data.extra.userProfile);
+                _this.userId = _this.userProfile.userId;
+            }
             logger.obj('joined', data);
             _this.emit('joined', data);
         });
@@ -221,7 +226,7 @@ var MinaraiClient = (function (_super) {
             body: {
                 message: uttr,
                 position: options.position || {},
-                extra: options.extra || {},
+                extra: Object.assign(options.extra || {}, { labels: this.userProfile.labels }),
             },
         };
         logger.obj('send', payload);

--- a/src/ts/minarai-client.ts
+++ b/src/ts/minarai-client.ts
@@ -46,6 +46,7 @@ export default class MinaraiClient extends EventEmitter2.EventEmitter2 {
   private deviceId: string|number;
   private lang: string|number;
   private userAuth: object;
+  private userProfile: object;
 
   constructor(opts: MinaraiClientConstructorOptions) {
     super();
@@ -80,6 +81,7 @@ export default class MinaraiClient extends EventEmitter2.EventEmitter2 {
     this.imageUrl = `${socketIORootURL.replace(/\/$/, '')}/${apiVersion}/upload-image`;
     this.getImageByHeader = opts.getImageByHeader;
     this.userAuth = opts.userAuth;
+    this.userProfile = {};
 
     logger.set({debug: opts.debug, silent: opts.silent});
   }
@@ -115,6 +117,11 @@ export default class MinaraiClient extends EventEmitter2.EventEmitter2 {
       this.clientId = data.clientId;
       this.userId = data.userId;
       this.deviceId = data.deviceId;
+
+      if (data.extra && data.extra.userProfile !== null) {
+        this.userProfile = Object.assign({}, this.userProfile, data.extra.userProfile);
+        this.userId = this.userProfile.userId;
+      }
 
       logger.obj('joined', data);
       this.emit('joined', data);
@@ -200,7 +207,7 @@ export default class MinaraiClient extends EventEmitter2.EventEmitter2 {
       body: {
         message: uttr,
         position: options.position || {},
-        extra: options.extra || {},
+        extra: Object.assign(options.extra || {}, { labels: this.userProfile.labels }),
       },
     };
     logger.obj('send', payload);


### PR DESCRIPTION
## 主旨

https://github.com/Nextremer/minarai-project/issues/977 のSDK側対応です。
本PRでは以下のことを解決する:

- 認証サーバから得たユーザ情報を`join`で受け取り、インスタンス変数として保持
- 保持している情報のうちラベル情報を`send`で送るようにした
    - ただし、ペイロード`body`直下に置くのはちょっと広めに調査が必要そうなのでいったん`extra`に入れた
    - 暫定。喫緊ではないため。はやく`body`直下に置きたい

## 理由

元issueの属するepicは「ユーザ認証を別のサーバに移譲し、そこから貰った情報をminarai全体で利用する」というものだが、現状D-Hubでは認証リクエストの結果を捨てている。そこで元issueでは以下2点を行うが、本PRはそのSDK側である:

- 認証サーバから貰った情報を`join`イベントでクライアントに流す
    - PR: https://github.com/Nextremer/minarai-daialogue-hub/pull/425
- `join`で受け取った情報を保持し、sendのときにlablesを送信する (イマココ)

## 期限

7/12 16:00くらいまで

## その他

### 注意事項

- こちらのPR https://github.com/Nextremer/minarai-client-sdk-js-socket.io/pull/28 がマージされるとコンフリクトする！

### 動作確認

ローカルのminarai-environmentで確認しました。

- `join`で渡ってきた情報を保持できていること
- `send` (D-Hubの`message`)をD-Hubで見るとlabelsが付いてきていること

#### 手順

1. こちらのPR https://github.com/Nextremer/minarai-daialogue-hub/pull/425 を適用
2. こちらの認証サーバ https://auth-mock-auth.herokuapp.com をDevConで設定
3. 以下のようなコマンドでhttps://github.com/Nextremer/minarai-cli-client-saas を起動

```shell
npm start -- --aid application_id --asc application_secret --url http://localhost:3007 --uid ok_woman --type raw
```

4. D-Hubに`console.log()`を仕込んでおき、`labels`が`request.body.extra`内に入っていることを確認
    - `handleMessage`のわりと頭に
    - このへん https://github.com/Nextremer/minarai-daialogue-hub/blob/qa/src/user.ts#L189