### PR TITLE
`userProfile`を`body`直下に (SDK)

### DIFF
--- a/dist/minarai-client.js
+++ b/dist/minarai-client.js
@@ -145,8 +145,8 @@ var MinaraiClient = (function (_super) {
             _this.clientId = data.clientId;
             _this.userId = data.userId;
             _this.deviceId = data.deviceId;
-            if (data.extra && data.extra.userProfile !== null) {
-                _this.userProfile = Object.assign({}, _this.userProfile, data.extra.userProfile);
+            if (data.userProfile !== null) {
+                _this.userProfile = Object.assign({}, _this.userProfile, data.userProfile);
                 _this.userId = _this.userProfile.userId;
             }
             logger.obj('joined', data);
@@ -226,7 +226,10 @@ var MinaraiClient = (function (_super) {
             body: {
                 message: uttr,
                 position: options.position || {},
-                extra: Object.assign(options.extra || {}, { labels: this.userProfile.labels }),
+                userProfile: {
+                    labels: this.userProfile.labels,
+                },
+                extra: options.extra,
             },
         };
         logger.obj('send', payload);

--- a/dist/minarai-client.js
+++ b/dist/minarai-client.js
@@ -145,7 +145,7 @@ var MinaraiClient = (function (_super) {
             _this.clientId = data.clientId;
             _this.userId = data.userId;
             _this.deviceId = data.deviceId;
-            if (data.userProfile !== null) {
+            if (!data.userProfile) {
                 _this.userProfile = Object.assign({}, _this.userProfile, data.userProfile);
                 _this.userId = _this.userProfile.userId;
             }

--- a/src/ts/minarai-client.ts
+++ b/src/ts/minarai-client.ts
@@ -118,8 +118,8 @@ export default class MinaraiClient extends EventEmitter2.EventEmitter2 {
       this.userId = data.userId;
       this.deviceId = data.deviceId;
 
-      if (data.extra && data.extra.userProfile !== null) {
-        this.userProfile = Object.assign({}, this.userProfile, data.extra.userProfile);
+      if (data.userProfile !== null) {
+        this.userProfile = Object.assign({}, this.userProfile, data.userProfile);
         this.userId = this.userProfile.userId;
       }
 
@@ -207,7 +207,10 @@ export default class MinaraiClient extends EventEmitter2.EventEmitter2 {
       body: {
         message: uttr,
         position: options.position || {},
-        extra: Object.assign(options.extra || {}, { labels: this.userProfile.labels }),
+        userProfile: {
+          labels: this.userProfile.labels,
+        },
+        extra: options.extra,
       },
     };
     logger.obj('send', payload);

--- a/src/ts/minarai-client.ts
+++ b/src/ts/minarai-client.ts
@@ -118,7 +118,7 @@ export default class MinaraiClient extends EventEmitter2.EventEmitter2 {
       this.userId = data.userId;
       this.deviceId = data.deviceId;
 
-      if (data.userProfile !== null) {
+      if (!data.userProfile) {
         this.userProfile = Object.assign({}, this.userProfile, data.userProfile);
         this.userId = this.userProfile.userId;
       }


### PR DESCRIPTION
## 改修概要

https://github.com/Nextremer/minarai-project/issues/977 で個人認証により得られたユーザのプロファイリング情報`userProfile`の追加を行った。しかし、わりと主要なデータにも関わらずペイロードの`extra`の中に押し込められて実装された。
そのため https://github.com/Nextremer/minarai-project/issues/991 で、重要なデータである`userProfile`を`body`直下に配置する改修を行う。

本PRでは上記の内、D-Hubが`extra`ではなく`body`直下に`userProfile`を入れてくるので、それに追随している。

※本PRはD-Hubが`body`直下に`userProfile`を置く改修をされている前提のPRである

## 関連PR

- D-Hub→SDKの修正
    - D-Hubの送る側の修正 ( https://github.com/Nextremer/minarai-daialogue-hub/pull/437/commits/932fbe82903dbe0ac62bec94a529926c9292c8ad )
    - D-Hubから受けたデータをconnectorに流すところの修正 ( https://github.com/Nextremer/minarai-connection-service/pull/121 )
    - D-Hubから受けたデータをインスタンス変数に格納するところの修正 (**本PR**)
- SDK→D-Hubの修正 ( https://github.com/Nextremer/minarai-daialogue-hub/pull/437/commits/2e8de21fd56b9360891831fba8105ab1485cc2f0 )

## その他

### TODO

- [ ] 影響箇所確認（レビュー時に利用しているところを指摘してもらう）
