### PR TITLE
getLogs時にuserAuthのtokenを送るようにする

### DIFF
--- a/dist/minarai-client.js
+++ b/dist/minarai-client.js
@@ -302,6 +302,7 @@ var MinaraiClient = (function (_super) {
                 timestampUnixTime: timestamp,
             },
             body: options,
+            userAuth: this.userAuth,
         };
         logger.obj('logs', payload);
         this.socket.emit('logs', payload);

--- a/src/ts/minarai-client.ts
+++ b/src/ts/minarai-client.ts
@@ -288,6 +288,7 @@ export default class MinaraiClient extends EventEmitter2.EventEmitter2 {
         timestampUnixTime: timestamp,
       },
       body: options,
+      userAuth: this.userAuth,
     };
     logger.obj('logs', payload);
     this.socket.emit('logs', payload);


### PR DESCRIPTION
## 概要

↑の通り！

## 詳細

`handleLogsでd-hubが受け取るparams`
```
{
  head:
  { applicationId: 'd334b557-64f8-43ba-9e78-9af8152e43e4',
    applicationSecret: '',
    clientId: 'dummy1563970282106',
    userId: 'dummy1563970282106',
    deviceId: 'device_id_d334b557-64f8-43ba-9e78-9af8152e43e4_1563970282957',
    timestampUnixTime: 1563970283726 },
  body: { limit: 20 },
  userAuth: { token: '' }
}
```

`d-hubから認証サーバへ送るparams`
```
{
  clientId: 'dummy1563970282106',
  deviceId: 'device_id_d334b557-64f8-43ba-9e78-9af8152e43e4_1563970282957',
  params:　{
    id: 'd334b557-64f8-43ba-9e78-9af8152e43e4dummy1563970282106dummy1563970282106device_id_d334b557-64f8-43ba-9e78-9af8152e43e4_1563970282957-1563970283726-logs',
    head:
     { applicationId: 'd334b557-64f8-43ba-9e78-9af8152e43e4',
       applicationSecret: '',
       clientId: 'dummy1563970282106',
       userId: 'dummy1563970282106',
       deviceId: 'device_id_d334b557-64f8-43ba-9e78-9af8152e43e4_1563970282957',
       timestampUnixTime: 1563970283726 },
    body: { limit: 20 },
    userAuth: { token: '' }
  },
  userId: 'dummy1563970282106'
}
```

handleJoinの時と、同階層のuserAuthにtokenがはいるため、とりあえず認証サーバではハンドリングできる。

`handleJoin時に認証サーバへ送るparams`
```
{
  clientId: 'dummy1563524471191',
  deviceId: 'device_id_d334b557-64f8-43ba-9e78-9af8152e43e4_1563524472045',
  params:
  { applicationId: 'd334b557-64f8-43ba-9e78-9af8152e43e4',
    applicationSecret: '',
    clientId: 'dummy1563524471191',
    userId: 'dummy1563524471191',
    deviceId: 'device_id_d334b557-64f8-43ba-9e78-9af8152e43e4_1563524472045',
    userAuth: { token: 'hogemiso' },
    connector: 'socketio',
  }
}
```

## 期限

味噌！