### PR TITLE
ユーザ識別情報の格納方法バグを修正

### DIFF
--- a/dist/minarai-client.js
+++ b/dist/minarai-client.js
@@ -145,7 +145,7 @@ var MinaraiClient = (function (_super) {
             _this.clientId = data.clientId;
             _this.userId = data.userId;
             _this.deviceId = data.deviceId;
-            if (!data.userProfile) {
+            if (data.userProfile) {
                 _this.userProfile = Object.assign({}, _this.userProfile, data.userProfile);
                 _this.userId = _this.userProfile.userId;
             }

--- a/dist/minarai-client.js
+++ b/dist/minarai-client.js
@@ -226,9 +226,7 @@ var MinaraiClient = (function (_super) {
             body: {
                 message: uttr,
                 position: options.position || {},
-                userProfile: {
-                    labels: this.userProfile.labels,
-                },
+                userProfile: this.userProfile,
                 extra: options.extra,
             },
         };

--- a/src/ts/minarai-client.ts
+++ b/src/ts/minarai-client.ts
@@ -207,9 +207,7 @@ export default class MinaraiClient extends EventEmitter2.EventEmitter2 {
       body: {
         message: uttr,
         position: options.position || {},
-        userProfile: {
-          labels: this.userProfile.labels,
-        },
+        userProfile: this.userProfile,
         extra: options.extra,
       },
     };

--- a/src/ts/minarai-client.ts
+++ b/src/ts/minarai-client.ts
@@ -118,7 +118,7 @@ export default class MinaraiClient extends EventEmitter2.EventEmitter2 {
       this.userId = data.userId;
       this.deviceId = data.deviceId;
 
-      if (!data.userProfile) {
+      if (data.userProfile) {
         this.userProfile = Object.assign({}, this.userProfile, data.userProfile);
         this.userId = this.userProfile.userId;
       }


### PR DESCRIPTION
## 主旨

https://github.com/Nextremer/minarai-project/issues/982 の対応について2点バグがあったので修正した:

- `userProfile`に格納される値が`labels`のみというバグ
- `userProfile`が`joined`の結果で更新されないバグ

## 理由

https://github.com/Nextremer/minarai-project/issues/977 で認証サーバはユーザ識別情報`userProfile`を格納するようになったが、その実装が意図と違っていたので修正した。

### 関連PR

- `userProfile`の追加PR: https://github.com/Nextremer/minarai-project/issues/977
- `userProfile`の移動PR: https://github.com/nextremer/minarai-project/issues/991

## 期限

8/2(金)までくらいに！

## その他

てへぺろ(・ω<)