### PR TITLE
ユーザ発話時のrequestIdのackを受け取る

### DIFF
--- a/dist/minarai-client.js
+++ b/dist/minarai-client.js
@@ -210,6 +210,7 @@ var MinaraiClient = (function (_super) {
         });
     };
     MinaraiClient.prototype.send = function (uttr, options) {
+        var _this = this;
         options = Object.assign({}, { lang: 'ja-JP' }, options || {});
         var timestamp = new Date().getTime();
         var payload = {
@@ -230,8 +231,12 @@ var MinaraiClient = (function (_super) {
                 extra: options.extra,
             },
         };
-        logger.obj('send', payload);
-        this.socket.emit('message', payload);
+        var makeAck = function (resolve) { return function (data) { return resolve(data); }; };
+        return new Promise(function (resolve) {
+            var ack = makeAck(resolve);
+            logger.obj('send', payload);
+            _this.socket.emit('message', payload, ack);
+        });
     };
     MinaraiClient.prototype.login = function (id, pass, token) {
         this.socket.emit('join-as-client', {

--- a/dist/minarai-client.js
+++ b/dist/minarai-client.js
@@ -231,6 +231,9 @@ var MinaraiClient = (function (_super) {
                 extra: options.extra,
             },
         };
+        // SocketIOのack機能でrequestIdを受け取っている
+        // 背景はこちら参照:
+        //   https://github.com/Nextremer/minarai-client-sdk-js-socket.io/pull/33
         var makeAck = function (resolve) { return function (data) { return resolve(data); }; };
         return new Promise(function (resolve) {
             var ack = makeAck(resolve);

--- a/src/ts/minarai-client.ts
+++ b/src/ts/minarai-client.ts
@@ -211,8 +211,13 @@ export default class MinaraiClient extends EventEmitter2.EventEmitter2 {
         extra: options.extra,
       },
     };
-    logger.obj('send', payload);
-    this.socket.emit('message', payload);
+
+    const makeAck = resolve => data => resolve(data);
+    return new Promise((resolve) => {
+      const ack = makeAck(resolve);
+      logger.obj('send', payload);
+      this.socket.emit('message', payload, ack);
+    });
   }
 
   public login(id, pass, token) {

--- a/src/ts/minarai-client.ts
+++ b/src/ts/minarai-client.ts
@@ -212,6 +212,9 @@ export default class MinaraiClient extends EventEmitter2.EventEmitter2 {
       },
     };
 
+    // SocketIOのack機能でrequestIdを受け取っている
+    // 背景はこちら参照:
+    //   https://github.com/Nextremer/minarai-client-sdk-js-socket.io/pull/33
     const makeAck = resolve => data => resolve(data);
     return new Promise((resolve) => {
       const ack = makeAck(resolve);


### PR DESCRIPTION
## 主旨

socketio-connectorに`message`イベント (D-HubのhandleMessage, connection-serviceの /req)を送ると、ack関数が付いている場合に限りrequestIdを受け取ることができるようになった。
そこで、それを受け取ってpromiseにくるんで返すようにした。

実現方法としてSocketIOのack機能を利用している ( https://socket.io/docs/#Sending-and-getting-data-acknowledgements )
サーバ側がどうなっているかはsocketio-connectorのPRも参照。

## 背景

https://github.com/Nextremer/minarai-project/issues/1017 において対話ログを更新したいが対象の対話を特定するにはrequestIdが必要である。そのため本PRと関連PRでrequestIdをクライアントまで返す改修を行った。

### 関連PR

- https://github.com/Nextremer/minarai-daialogue-hub/pull/469 D-Hubの修正
- https://github.com/Nextremer/minarai-connection-service/pull/129 connection-serviceの修正
- https://github.com/Nextremer/minarai-socketio-connector/pull/102 socketio-connectorの修正
- https://github.com/Nextremer/minarai-client-sdk-js-socket.io/pull/33 client-sdk-socketioの修正  **イマココ**

## 確認項目

- minarai-client-sdk-js-socket-ioがmasterの状態 (旧SDK状態)で発話が正常に行えること
- minarai-cli-client-saasでsendしている箇所を以下のように書き換え、requestIdが降ってくることを確認

```diff
-  minaraiClient.send(msg, jsonMessage);
+  minaraiClient.send(msg, jsonMessage).then(ack => console.log(ack));
```
